### PR TITLE
Fix cookie key to make it compatible with fastapi

### DIFF
--- a/core/lib/cookie.ts
+++ b/core/lib/cookie.ts
@@ -57,7 +57,8 @@ export function defaultCookies(useSecureCookies: boolean): CookiesOptions {
   return {
     // default cookie options
     sessionToken: {
-      name: `${cookiePrefix}next-auth.session-token`,
+      // name: `${cookiePrefix}next-auth.session-token`,
+      name: 'fastapi_session',
       options: {
         httpOnly: true,
         sameSite: "lax",


### PR DESCRIPTION
next-auth기본은 `__Secure-next-`어쩌고인데 fastapi 서버에서 쿠키 접근할 때 앞에 `__` 붙는 걸 못읽어서 수정함